### PR TITLE
add 'when-assert' as a separate macro

### DIFF
--- a/src/pjstadig/assertions.clj
+++ b/src/pjstadig/assertions.clj
@@ -9,11 +9,20 @@
 (ns pjstadig.assertions
   (:refer-clojure :exclude [assert]))
 
+
+(defmacro when-assert
+  "Execute body of code only if assertions are enabled."
+  [& body]
+  `(when pjstadig.Assertions/assertionsEnabled
+     ~@body))
+
+
 (defmacro assert
+  "Evaluate form. Return nil on truthy result, throw AssertionError otherwise."
   ([form]
      `(assert ~form ~(pr-str form)))
   ([form msg]
-     `(if pjstadig.Assertions/assertionsEnabled
+     `(when-assert
         (if ~form
           nil
           (throw (AssertionError. ~msg))))))


### PR DESCRIPTION
This PR will enable users to carry out extended assertions beyond what this library provides (e.g. with [prismatic/schema](https://github.com/Prismatic/schema) or custom validations) using `when-assert`.
